### PR TITLE
fix: External modules cause plugin to crash

### DIFF
--- a/src/bundle-info.ts
+++ b/src/bundle-info.ts
@@ -57,7 +57,7 @@ export async function parseBundleInfo(bundleAsts: Record<string, SWC.Module>): P
 
     // Add reverse edges for dependency graph traversal
     moduleInfo.imported.forEach(importedModuleName => {
-      bundleInfo[importedModuleName].importedBy.push(moduleName);
+      bundleInfo[importedModuleName]?.importedBy.push(moduleName);
     });
 
     moduleInfo.transformNeeded = findTopLevelAwait(ast);

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -228,7 +228,7 @@ export function transformModule(ast: SWC.Module, moduleName: string, bundleInfo:
     const importedModuleName = resolveImport(moduleName, importDeclaration.source.value);
     if (!importedModuleName) continue;
 
-    if (bundleInfo[importedModuleName].transformNeeded) {
+    if (bundleInfo[importedModuleName]?.transformNeeded) {
       importDeclaration.specifiers.push(
         makeImportSpecifier(options.promiseExportName, options.promiseImportName(importedPromiseCount))
       );


### PR DESCRIPTION
## Problem
When using Vite in library mode and specifying external peer dependencies (in `vite.config.ts` and `package.json`) these dependencies are included in the asts of modules with type `ImportDeclaration`, but not as modules in `bundleAsts` (they are not part of the build output). This results in two cases where `bundleInfo[importedModuleName]` might be undefined.

Resulting error:
```
[vite-plugin-top-level-await] Cannot read property 'importedBy' of undefined
error during build:
TypeError: Cannot read property 'importedBy' of undefined
    at /sandbox/node_modules/vite-plugin-top-level-await/dist/bundle-info.js:64:44
    at Array.forEach (<anonymous>)
    at parseBundleInfo (/sandbox/node_modules/vite-plugin-top-level-await/dist/bundle-info.js:63:29)
    at Object.generateBundle (/sandbox/node_modules/vite-plugin-top-level-await/dist/index.js:60:72)
    at async Bundle.generate (file:///sandbox/node_modules/rollup/dist/es/shared/rollup.js:15972:9)
    at async file:///sandbox/node_modules/rollup/dist/es/shared/rollup.js:23708:27
    at async catchUnfinishedHookActions (file:///sandbox/node_modules/rollup/dist/es/shared/rollup.js:23040:20)
    at async doBuild (file:///sandbox/node_modules/vite/dist/node/chunks/dep-1513d487.js:43468:26)
    at async build (file:///sandbox/node_modules/vite/dist/node/chunks/dep-1513d487.js:43297:16)
    at async CAC.<anonymous> (file:///sandbox/node_modules/vite/dist/node/cli.js:747:9)
```

Reproduction: https://codesandbox.io/s/top-level-await-issue-oww7ze (fork and run build)

## Fix
Added optional chaining to the two cases. That fixes the issue on my side at least.