### PR TITLE
fix: unchecked index access on `bundleInfo`

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -285,7 +285,7 @@ export function transformModule(
   let importedPromiseCount = 0;
   for (const importDeclaration of imports) {
     const importedModuleName = resolveImport(moduleName, importDeclaration.source.value);
-    if (!importedModuleName) continue;
+    if (!importedModuleName || !bundleInfo[importedModuleName]) continue;
 
     if (bundleInfo[importedModuleName].transformNeeded) {
       importDeclaration.specifiers.push(


### PR DESCRIPTION
Hello,

We were seeing a crash when building our storybook and this change fixed it. I don't know the exact problem so perhaps there's a better fix 🤷.

Relevant stacktrace:

```
✓ 8898 modules transformed.
rendering chunks (139)...[vite-plugin-top-level-await] Non-existing module "sb-preview/runtime.js" imported by "assets/WithTooltip-J57HCPYA-f7b01cbd.js", ignoring.
[vite-plugin-top-level-await] Non-existing module "sb-preview/runtime.js" imported by "assets/syntaxhighlighter-PONEFOSF-67147e35.js", ignoring.
[vite-plugin-top-level-await] Non-existing module "sb-preview/runtime.js" imported by "assets/preview-86687123.js", ignoring.
[vite-plugin-top-level-await] Non-existing module "sb-preview/runtime.js" imported by "assets/GlobalScrollAreaStyles-UY5SB7EJ-d25b2398.js", ignoring.
[vite-plugin-top-level-await] Non-existing module "sb-preview/runtime.js" imported by "assets/iframe-5053bcc3.js", ignoring.
[vite-plugin-top-level-await] Non-existing module "sb-preview/runtime.js" imported by "assets/formatter-SWP5E3XI-0c605398.js", ignoring.
[vite-plugin-top-level-await] Non-existing module "sb-preview/runtime.js" imported by "assets/Color-6VNJS4EI-a1a2ac64.js", ignoring.
[vite-plugin-top-level-await] Non-existing module "sb-preview/runtime.js" imported by "assets/PDFViewer.stories-86b6fb6e.js", ignoring.
[vite-plugin-top-level-await] Cannot read properties of undefined (reading 'transformNeeded')
✓ built in 38.91s
TypeError: Cannot read properties of undefined (reading 'transformNeeded')
    at transformModule (/Users/stefan/project/node_modules/vite-plugin-top-level-await/dist/transform.js:246:44)
    at /Users/stefan/project/node_modules/vite-plugin-top-level-await/dist/index.js:102:64
    at Array.map (<anonymous>)
    at Object.generateBundle (/Users/stefan/project/node_modules/vite-plugin-top-level-await/dist/index.js:95:57)
    at async Bundle.generate (file:///Users/stefan/project/node_modules/vite/node_modules/rollup/dist/es/shared/node-entry.js:17930:9)
    at async file:///Users/stefan/project/node_modules/vite/node_modules/rollup/dist/es/shared/node-entry.js:26785:27
    at async catchUnfinishedHookActions (file:///Users/stefan/project/node_modules/vite/node_modules/rollup/dist/es/shared/node-entry.js:25910:16)
    at async Module.build (file:///Users/stefan/project/node_modules/vite/dist/node/chunks/dep-68d1a114.js:48085:22)
    at async build (/Users/stefan/project/node_modules/@storybook/builder-vite/dist/index.js:159:11024)
    at async Promise.all (index 0)
    at async Module.build2 (/Users/stefan/project/node_modules/@storybook/builder-vite/dist/index.js:159:13356)
    at async Promise.all (index 0)
    at async buildStaticStandalone (/Users/stefan/project/node_modules/@storybook/core-server/dist/index.js:97:4608)
    at async withTelemetry (/Users/stefan/project/node_modules/@storybook/core-server/dist/index.js:101:4155)
    at async build (/Users/stefan/project/node_modules/@storybook/cli/dist/generate.js:473:1059)
    at async Command.<anonymous> (/Users/stefan/project/node_modules/@storybook/cli/dist/generate.js:476:125)
```

Maybe it would be useful if `strict` was enabled and `"noUncheckedIndexedAccess": true,` was added to `tsconfig.json`? I tried turning it on but there are a lot of places that would need to be updated and you probably want to do it yourself.

Thanks!
