### PR TITLE
Generate sourceMappingURL into javascript file

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "noFallthroughCasesInSwitch": false,
     "baseUrl": "./",
     "outDir": "./dist",
-    "declaration": true
+    "declaration": true,
+    "sourceMap": true,
   },
   "include": [
     "src"


### PR DESCRIPTION
this fix configure the auto-generate sourceMappingURL in every build javscript file

#34 