### PR TITLE
fix: parse ExportNamedDeclaration with source

### DIFF
--- a/src/bundle-info.spec.ts
+++ b/src/bundle-info.spec.ts
@@ -41,6 +41,37 @@ describe("Bundle info parser", () => {
     }
   });
 
+  it("should parse dependencies correctly", async () => {
+    const chunks = {
+      a: `
+        export { x } from "./b";
+        import { s } from "./c";
+        const w = await globalThis.y?.z(s);
+        export { w };
+      `,
+      b: `
+        const x = await globalThis.x?.y;
+        export { x };
+      `,
+      c: `
+        const s = await globalThis.p?.q;
+        export { s };
+      `
+    };
+
+    const bundleInfo = await parseBundleInfo(await parseBundleAsts(chunks));
+
+    expect(bundleInfo["a"]).toBeTruthy();
+    expect(bundleInfo["a"].imported).toIncludeSameMembers(["b", "c"]);
+    expect(bundleInfo["a"].importedBy).toIncludeSameMembers([]);
+    expect(bundleInfo["b"]).toBeTruthy();
+    expect(bundleInfo["b"].imported).toIncludeSameMembers([]);
+    expect(bundleInfo["b"].importedBy).toIncludeSameMembers(["a"]);
+    expect(bundleInfo["c"]).toBeTruthy();
+    expect(bundleInfo["c"].imported).toIncludeSameMembers([]);
+    expect(bundleInfo["c"].importedBy).toIncludeSameMembers(["a"]);
+  });
+
   it("should parse dependency graph correctly", async () => {
     const dependencyGraph = {
       a: ["b", "c", "d"],

--- a/src/bundle-info.ts
+++ b/src/bundle-info.ts
@@ -50,7 +50,7 @@ export async function parseBundleInfo(bundleAsts: Record<string, SWC.Module>): P
     // Parse imports
     moduleInfo.imported = ast.body
       .map(item => {
-        if (item.type === "ImportDeclaration") {
+        if (item.type === "ImportDeclaration" || (item.type === "ExportNamedDeclaration" && item.source)) {
           return resolveImport(moduleName, item.source.value);
         }
       })

--- a/src/transform.spec.ts
+++ b/src/transform.spec.ts
@@ -392,6 +392,39 @@ describe("Transform top-level await", () => {
     );
   });
 
+  it("should work for a module with export-from statements", () => {
+    test(
+      "a",
+      {
+        a: { imported: ["./b"], importedBy: [], transformNeeded: true, withTopLevelAwait: true },
+        b: { imported: [], importedBy: ["./a"], transformNeeded: true, withTopLevelAwait: true }
+      },
+      `
+      import { qwq } from "./b";
+      export { owo as uwu, default as ovo } from "./b";
+      export * as QwQ from "./b";
+      const qaq = await globalThis.someFunc(qwq);
+      export { qaq };
+    `,
+      `
+      import { qwq, __tla as __tla_0 } from "./b";
+      import { __tla as __tla_1 } from "./b";
+      import { __tla as __tla_2 } from "./b";
+      export { owo as uwu, default as ovo } from "./b";
+      export * as QwQ from "./b";
+      let qaq;
+      let __tla = Promise.all([
+        (() => { try { return __tla_0; } catch {} })(),
+        (() => { try { return __tla_1; } catch {} })(),
+        (() => { try { return __tla_2; } catch {} })(),
+      ]).then(async () => {
+        qaq = await globalThis.someFunc(qwq);
+      });
+      export { qaq, __tla };
+    `
+    );
+  });
+
   it("should skip processing imports of external modules", () => {
     test(
       "a",

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -18,7 +18,7 @@ import {
   makeExportListDeclaration,
   makeStatement,
   makeAwaitExpression,
-  transformExportNamedToImport
+  makeImportDeclaration
 } from "./utils/make-node";
 import { RandomIdentifierGenerator } from "./utils/random-identifier";
 import { resolveImport } from "./utils/resolve-import";
@@ -87,10 +87,11 @@ export function transformModule(
   // Extract import declarations
   const imports = ast.body.filter((item): item is SWC.ImportDeclaration => item.type === "ImportDeclaration");
 
-  const exportFromImport = ast.body.filter(
+  // Handle `export { named as renamed } from "module";`
+  const exportFroms = ast.body.filter(
     (item): item is SWC.ExportNamedDeclaration => item.type === "ExportNamedDeclaration" && !!item.source
   );
-  const importFromExportList: SWC.ImportDeclaration[] = [];
+  const newImportsByExportFroms: SWC.ImportDeclaration[] = [];
 
   const exportMap: Record<string, string> = {};
 
@@ -136,15 +137,18 @@ export function transformModule(
         }
 
         return false;
+      // Handle `export { named as renamed };` without "from"
       case "ExportNamedDeclaration":
-        item.specifiers.forEach(specifier => {
-          /* istanbul ignore if */
-          if (specifier.type !== "ExportSpecifier") {
-            raiseUnexpectedNode("export specifier", specifier.type);
-          }
+        if (!item.source) {
+          item.specifiers.forEach(specifier => {
+            /* istanbul ignore if */
+            if (specifier.type !== "ExportSpecifier") {
+              raiseUnexpectedNode("export specifier", specifier.type);
+            }
 
-          exportMap[(specifier.exported || specifier.orig).value] = specifier.orig.value;
-        });
+            exportMap[(specifier.exported || specifier.orig).value] = specifier.orig.value;
+          });
+        }
 
         return true;
     }
@@ -187,11 +191,19 @@ export function transformModule(
   const importedNames = new Set(
     imports.flatMap(importStmt => importStmt.specifiers.map(specifier => specifier.local.value))
   );
-  exportFromImport.flatMap(importStmt => importStmt.specifiers.map((specifier:SWC.NamedExportSpecifier) => specifier.orig.value)).forEach(item=>importedNames.add(item))
-
-  const exportedNamesDeclaration = makeVariablesDeclaration(
-    exportedNames.filter(name => !importedNames.has(name))
+  const exportFromedNames = new Set(
+    exportFroms.flatMap(exportStmt => exportStmt.specifiers.map(specifier => {
+      if (specifier.type === "ExportNamespaceSpecifier") {
+        return specifier.name.value;
+      } else if (specifier.type === "ExportDefaultSpecifier") {
+        // When will this happen?
+        return specifier.exported.value;
+      } else {
+        return (specifier.exported || specifier.orig).value;
+      }
+    }))
   );
+  const exportedNamesDeclaration = makeVariablesDeclaration(exportedNames.filter(name => !importedNames.has(name) && !exportFromedNames.has(name)));
 
   const warppedStatements = topLevelStatements.flatMap<SWC.Statement>(stmt => {
     if (stmt.type === "VariableDeclaration") {
@@ -294,28 +306,21 @@ export function transformModule(
 
   // Add import of TLA promises from imported modules
   let importedPromiseCount = 0;
-  for (const importDeclaration of imports) {
-    const importedModuleName = resolveImport(moduleName, importDeclaration.source.value);
+  for (const declaration of [...imports, ...exportFroms]) {
+    const importedModuleName = resolveImport(moduleName, declaration.source.value);
     if (!importedModuleName || !bundleInfo[importedModuleName]) continue;
 
     if (bundleInfo[importedModuleName].transformNeeded) {
-      importDeclaration.specifiers.push(
+      let targetImportDeclaration: SWC.ImportDeclaration;
+      if (declaration.type === "ImportDeclaration") {
+        targetImportDeclaration = declaration;
+      } else {
+        targetImportDeclaration = makeImportDeclaration(declaration.source);
+        newImportsByExportFroms.push(targetImportDeclaration);
+      }
+      targetImportDeclaration.specifiers.push(
         makeImportSpecifier(options.promiseExportName, options.promiseImportName(importedPromiseCount))
       );
-      importedPromiseCount++;
-    }
-  }
-
-  for (const exportNamedDeclaration of exportFromImport) {
-    const importedModuleName = resolveImport(moduleName, exportNamedDeclaration.source.value);
-    if (!importedModuleName || !bundleInfo[importedModuleName]) continue;
-
-    if (bundleInfo[importedModuleName].transformNeeded) {
-      const newImportDeclaration = transformExportNamedToImport(exportNamedDeclaration);
-      newImportDeclaration.specifiers.push(
-        makeImportSpecifier(options.promiseExportName, options.promiseImportName(importedPromiseCount))
-      );
-      importFromExportList.push(newImportDeclaration);
       importedPromiseCount++;
     }
   }
@@ -363,7 +368,7 @@ export function transformModule(
    * export { ..., __tla };
    */
 
-  const newTopLevel: SWC.ModuleItem[] = [...imports, ...importFromExportList, exportedNamesDeclaration];
+  const newTopLevel: SWC.ModuleItem[] = [...imports, ...newImportsByExportFroms, ...exportFroms, exportedNamesDeclaration];
 
   if (exportedNames.length > 0 || bundleInfo[moduleName]?.importedBy?.length > 0) {
     // If the chunk is being imported, append export of the TLA promise to export list

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -187,9 +187,10 @@ export function transformModule(
   const importedNames = new Set(
     imports.flatMap(importStmt => importStmt.specifiers.map(specifier => specifier.local.value))
   );
+  exportFromImport.flatMap(importStmt => importStmt.specifiers.map((specifier:SWC.NamedExportSpecifier) => specifier.orig.value)).forEach(item=>importedNames.add(item))
 
   const exportedNamesDeclaration = makeVariablesDeclaration(
-    exportFromImport.length ? [] : exportedNames.filter(name => !importedNames.has(name))
+    exportedNames.filter(name => !importedNames.has(name))
   );
 
   const warppedStatements = topLevelStatements.flatMap<SWC.Statement>(stmt => {

--- a/src/utils/make-node.ts
+++ b/src/utils/make-node.ts
@@ -1,5 +1,4 @@
 import * as SWC from "@swc/core";
-import { Span } from "@swc/core";
 
 function span(): SWC.Span {
   return { start: 0, end: 0, ctxt: 0 };
@@ -233,22 +232,13 @@ export function makeAwaitExpression(expression: SWC.Expression): SWC.AwaitExpres
   };
 }
 
-export function transformExportNamedToImport(exportNamedDeclNode: any): SWC.ImportDeclaration {
-  // Transform each ExportSpecifier into an ImportSpecifier
-  const importSpecifiers: SWC.ImportSpecifier[] = exportNamedDeclNode.specifiers.map(specifier => {
-    return {
-      type: "ImportSpecifier",
-      local: specifier.orig,
-      span: span()
-    };
-  });
-
+export function makeImportDeclaration(source: SWC.StringLiteral): SWC.ImportDeclaration {
   const importDeclaration: SWC.ImportDeclaration = {
     type: "ImportDeclaration",
-    specifiers: importSpecifiers,
-    source: exportNamedDeclNode.source,
+    specifiers: [],
+    source,
     span: span(),
-    typeOnly: false // Set based on your requirements
+    typeOnly: false
   };
 
   return importDeclaration;

--- a/src/utils/make-node.ts
+++ b/src/utils/make-node.ts
@@ -1,4 +1,5 @@
 import * as SWC from "@swc/core";
+import { Span } from "@swc/core";
 
 function span(): SWC.Span {
   return { start: 0, end: 0, ctxt: 0 };
@@ -230,4 +231,25 @@ export function makeAwaitExpression(expression: SWC.Expression): SWC.AwaitExpres
     span: span(),
     argument: expression
   };
+}
+
+export function transformExportNamedToImport(exportNamedDeclNode: any): SWC.ImportDeclaration {
+  // Transform each ExportSpecifier into an ImportSpecifier
+  const importSpecifiers: SWC.ImportSpecifier[] = exportNamedDeclNode.specifiers.map(specifier => {
+    return {
+      type: "ImportSpecifier",
+      local: specifier.orig,
+      span: span()
+    };
+  });
+
+  const importDeclaration: SWC.ImportDeclaration = {
+    type: "ImportDeclaration",
+    specifiers: importSpecifiers,
+    source: exportNamedDeclNode.source,
+    span: span(),
+    typeOnly: false // Set based on your requirements
+  };
+
+  return importDeclaration;
 }


### PR DESCRIPTION
This PR fixes the parse of files that contain named exports directly from a source file.

closes #45 