### PR TITLE
fix: handle await detection in method property

### DIFF
--- a/src/find.spec.ts
+++ b/src/find.spec.ts
@@ -116,4 +116,17 @@ describe("Find top-level await usage in module", () => {
     `
     );
   });
+
+  it("should work with await in object method property", () => {
+    test(
+      null,
+      `
+      const obj = {
+        async method() {
+          await x.func();
+        }
+      }
+    `
+    );
+  });
 });

--- a/src/find.ts
+++ b/src/find.ts
@@ -33,6 +33,7 @@ class FindPatternsVisitor extends Visitor {
     hook("visitClass");
     hook("visitArrowFunctionExpression");
     hook("visitFunction");
+    hook("visitMethodProperty");
   }
 
   visitAwaitExpression(expr: SWC.AwaitExpression): SWC.Expression {


### PR DESCRIPTION
Discovered from https://github.com/withastro/astro/issues/11534, it's incorrectly marking the await at [this Astro code](https://github.com/withastro/astro/blob/536209aa74924dbde4084026e3b72832961813ac/packages/astro/src/assets/services/sharp.ts#L48) as a TLA, as it's inside a method property of an object.