### PR TITLE
this.document and this.location.href do not exist in a web worker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ export default function topLevelAwait(options?: Options): Plugin {
         newEntry.code = (
           await esbuild.transform(
             // Polyfill `document.currentScript.src` since it's used for `import.meta.url`.
-            `if (typeof document !== 'undefined') { this.document = { currentScript: { src: this.location.href } }; }\n${newEntry.code}`,
+            `if (typeof document !== 'undefined') { this.document = { currentScript: { src: self.location.href } }; }\n${newEntry.code}`,
             {
               minify,
               target: buildTarget as string | string[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ export default function topLevelAwait(options?: Options): Plugin {
         newEntry.code = (
           await esbuild.transform(
             // Polyfill `document.currentScript.src` since it's used for `import.meta.url`.
-            `if (typeof document !== 'undefined') { this.document = { currentScript: { src: self.location.href } }; }\n${newEntry.code}`,
+            `self.document = { currentScript: { src: self.location.href } };\n${newEntry.code}`,
             {
               minify,
               target: buildTarget as string | string[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ export default function topLevelAwait(options?: Options): Plugin {
         newEntry.code = (
           await esbuild.transform(
             // Polyfill `document.currentScript.src` since it's used for `import.meta.url`.
-            `this.document = { currentScript: { src: self.location.href } };\n${newEntry.code}`,
+            `if (typeof document !== 'undefined') { this.document = { currentScript: { src: this.location.href } }; }\n${newEntry.code}`,
             {
               minify,
               target: buildTarget as string | string[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ export default function topLevelAwait(options?: Options): Plugin {
         newEntry.code = (
           await esbuild.transform(
             // Polyfill `document.currentScript.src` since it's used for `import.meta.url`.
-            `this.document = { currentScript: { src: this.location.href } };\n${newEntry.code}`,
+            `this.document = { currentScript: { src: self.location.href } };\n${newEntry.code}`,
             {
               minify,
               target: buildTarget as string | string[]


### PR DESCRIPTION
if you use this plugin in a web worker, it will work in development, but not in production.

it fails in production first because this.location does not exist in a web worker. this can be fixed by changing it to self.location.

however, more fundamentally, document does not exist inside a web worker. you cannot do this.document = [anything] in a web worker.

but, this line is actually a polyfill. self does exist in a web worker, and we can polyfill self.document exactly like in a normal web page.

in a nutshell, if you change both instances of "this" to "self", this plugin works in a web worker in production.