### PR TITLE
chore: avoid publish test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
   },
   "files": [
     "/dist",
+    "!/dist/**/*.spec.js",
+    "!/dist/**/*.spec.d.ts",
     "/exports"
   ]
 }


### PR DESCRIPTION
close https://github.com/Menci/vite-plugin-top-level-await/issues/54

The CI publish workflow uses npm, so we can use `files` to remove the test files from publishing.

Tested with `npm pack` locally:

```bash
bjorn@Bjorns-MacBook-Pro vite-plugin-top-level-await % npm pack
npm notice
npm notice 📦  vite-plugin-top-level-await@1.4.3
npm notice Tarball Contents
npm notice 1.1kB LICENSE
npm notice 4.2kB README.md
npm notice 449B dist/bundle-info.d.ts
npm notice 4.0kB dist/bundle-info.js
npm notice 75B dist/esbuild.d.ts
npm notice 816B dist/esbuild.js
npm notice 217B dist/find.d.ts
npm notice 2.7kB dist/find.js
npm notice 176B dist/index.d.ts
npm notice 6.9kB dist/index.js
npm notice 245B dist/options.d.ts
npm notice 215B dist/options.js
npm notice 261B dist/transform.d.ts
npm notice 13.1kB dist/transform.js
npm notice 84B dist/utils/error.d.ts
npm notice 376B dist/utils/error.js
npm notice 1.7kB dist/utils/make-node.d.ts
npm notice 6.5kB dist/utils/make-node.js
npm notice 125B dist/utils/random-identifier.d.ts
npm notice 559B dist/utils/random-identifier.js
npm notice 79B dist/utils/resolve-import.d.ts
npm notice 378B dist/utils/resolve-import.js
npm notice 115B dist/utils/resolve-pattern.d.ts
npm notice 1.3kB dist/utils/resolve-pattern.js
npm notice 105B exports/import.mjs
npm notice 110B exports/require.cjs
npm notice 137B exports/require.d.cts
npm notice 1.5kB package.json
npm notice Tarball Details
npm notice name: vite-plugin-top-level-await
npm notice version: 1.4.3
npm notice filename: vite-plugin-top-level-await-1.4.3.tgz
npm notice package size: 12.7 kB
npm notice unpacked size: 47.6 kB
npm notice shasum: 803a40fb793232806a8e4c8e326240d540f5c8e1
npm notice integrity: sha512-PaRXZKSynxSAZ[...]kTR9RajHCHa0Q==
npm notice total files: 28
npm notice
vite-plugin-top-level-await-1.4.3.tgz
```